### PR TITLE
update electron api accelerator reference (readme / settings page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an [Obsidian](https://obsidian.md) plugin, adding support for system-wid
 
 In the `Global Hotkeys` settings, you can enter a system-wide key combination that
 will perform the specified command. The key combination is specified following
-[Electron's Accelerators](https://www.electronjs.org/docs/api/accelerator).
+[Electron's Accelerators](https://www.electronjs.org/docs/latest/api/accelerator#available-modifiers).
 
 ## To-Do
 

--- a/main.ts
+++ b/main.ts
@@ -160,7 +160,7 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
       text.appendText("For information on key bindings, see documentation ");
 
       const link = document.createElement('a');
-      link.setAttribute('href', "https://www.electronjs.org/docs/api/accelerator#available-modifiers");
+      link.setAttribute('href', "https://www.electronjs.org/docs/latest/api/accelerator#available-modifiers");
       link.textContent = "here";
       text.appendChild(link);
 


### PR DESCRIPTION
The current reference is outdated 