### PR TITLE
feat: add `ControlOrSuper` modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ will perform the specified command. The key combination is specified following
 
 The plugin also defines the following special keys:
 
-`SuperOrControl`(or `SuperOrCtrl` for short): Represents `Control` on macOS and `Windows` on Linxu and Windows.
+`ControlOrSuper`(or `CtrlOrSuper` for short): Represents `Control` on macOS and `Windows` on Linxu and Windows.
 
 ## To-Do
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ In the `Global Hotkeys` settings, you can enter a system-wide key combination th
 will perform the specified command. The key combination is specified following
 [Electron's Accelerators](https://www.electronjs.org/docs/api/accelerator).
 
+The plugin also defines the following special keys:
+
+`SuperOrControl`(or `SuperOrCtrl` for short): Represents `Control` on macOS and `Windows` on Linxu and Windows.
+
 ## To-Do
 
 - Improve hotkey settings

--- a/main.ts
+++ b/main.ts
@@ -42,7 +42,7 @@ export default class GlobalHotkeysPlugin extends Plugin {
 
     let success = (() => {
       try {
-        return globalShortcut.register(accelerator, () => {
+        return globalShortcut.register(remapHotkey(accelerator), () => {
           const command = app.commands.commands[command_id];
           if (!command) return;
           this.app.setting.close(); // Ensure all modals are closed?
@@ -76,7 +76,7 @@ export default class GlobalHotkeysPlugin extends Plugin {
   async unregisterGlobalShortcut(command_id:string) {
     const accelerator = this.currentlyMapped[command_id];
     if (accelerator) {
-      globalShortcut.unregister(accelerator);
+      globalShortcut.unregister(remapHotkey(accelerator));
       delete this.currentlyMapped[command_id];
     }
   }
@@ -217,10 +217,9 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
         .addText(text => text
                  .setPlaceholder('Hotkey')
                  .setValue(accelerator)
-                 .onChange(async (rawValue) => {
+                 .onChange(async (value) => {
                    const inputEl = setting.components[0].inputEl;
-                   if (rawValue) {
-                     const value = remapHotkey(rawValue)
+                   if (value) {
                      this.plugin.registerGlobalShortcut(cmd, value, async (success) => {
                        if (success) {
                          inputEl.classList.remove('invalid-accelerator');

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,26 @@
 import { App, Modal, Notice, Platform, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import * as os from 'node:os'
 const remote = require('electron').remote;
 const globalShortcut = remote.globalShortcut;
+
+const KEY_MAP_MACOS = {
+  'SuperOrControl': 'Control',
+  'SuperOrCtrl': 'Ctrl',
+};
+
+const KEY_MAP_PC = {
+  'SuperOrControl': 'Super',
+  'SuperOrCtrl': 'Super',
+};
+
+const KEY_MAP: Record<string, string> = os.platform() === 'darwin' ? KEY_MAP_MACOS : KEY_MAP_PC
+
+function remapHotkey(hotkey: string) {
+  return hotkey.split('+')
+    .map(it => it.trim())
+    .map(it => KEY_MAP[it] ?? it)
+    .join('+')
+}
 
 interface GlobalHotkeysPluginSettings {
   accelerators: { [key: string]: string };
@@ -197,9 +217,10 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
         .addText(text => text
                  .setPlaceholder('Hotkey')
                  .setValue(accelerator)
-                 .onChange(async (value) => {
+                 .onChange(async (rawValue) => {
                    const inputEl = setting.components[0].inputEl;
-                   if (value) {
+                   if (rawValue) {
+                     const value = remapHotkey(rawValue)
                      this.plugin.registerGlobalShortcut(cmd, value, async (success) => {
                        if (success) {
                          inputEl.classList.remove('invalid-accelerator');

--- a/main.ts
+++ b/main.ts
@@ -4,13 +4,13 @@ const remote = require('electron').remote;
 const globalShortcut = remote.globalShortcut;
 
 const KEY_MAP_MACOS = {
-  'SuperOrControl': 'Control',
-  'SuperOrCtrl': 'Ctrl',
+  'ControlOrSuper': 'Control',
+  'CtrlOrSuper': 'Ctrl',
 };
 
 const KEY_MAP_PC = {
-  'SuperOrControl': 'Super',
-  'SuperOrCtrl': 'Super',
+  'ControlOrSuper': 'Super',
+  'CtrlOrSuper': 'Super',
 };
 
 const KEY_MAP: Record<string, string> = os.platform() === 'darwin' ? KEY_MAP_MACOS : KEY_MAP_PC


### PR DESCRIPTION
`ControlOrSuper`(or `CtrlOrSuper` for short) represents `Control` on macOS and `Windows` on Linxu and Windows.

