### PR TITLE
Hotkey for new window

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -26,19 +26,19 @@ export default class GlobalHotkeysPlugin extends Plugin {
           const command = (this.app as any).commands.commands[command_id];
           if (!command) return;
           (this.app as any).setting.close(); // Ensure all modals are closed?
-          const anyFocusedBefore = (remote.BrowserWindow as any).getAllWindows().some((w: any) => w.isFocused());
-          const win = remote.getCurrentWindow();
+          const mainWindow = remote.getCurrentWindow();
 
           if (command.checkCallback)
             command.checkCallback(false);
           else if (command.callback)
             command.callback();
 
-          // only activate Obsidian if no window is currently focused.
-          // This prevents stealing focus from a newly created window.
-          const anyFocusedAfter = (remote.BrowserWindow as any).getAllWindows().some((w: any) => w.isFocused());
-          if (!anyFocusedBefore && !anyFocusedAfter)
-            remote.getCurrentWindow().show(); // Activate obsidian
+          // If a secondary window is focused (e.g. a newly created window), stay put.
+          // Otherwise, bring the main window to the front as intended by the README.
+          const focusedWindow = (remote.BrowserWindow as any).getFocusedWindow();
+          if (!focusedWindow || focusedWindow.id === mainWindow.id) {
+            mainWindow.show();
+          }
         });
       } catch (error) {
         return false;

--- a/main.ts
+++ b/main.ts
@@ -14,8 +14,8 @@ export default class GlobalHotkeysPlugin extends Plugin {
   settings: GlobalHotkeysPluginSettings;
   currentlyMapped: { [key: string]: string };
 
-  async registerGlobalShortcut(command_id:string, accelerator:string,
-                               oncomplete?:(success:boolean)=>void) {
+  async registerGlobalShortcut(command_id: string, accelerator: string,
+    oncomplete?: (success: boolean) => void) {
     if (command_id in this.currentlyMapped) {
       this.unregisterGlobalShortcut(command_id);
     }
@@ -26,17 +26,18 @@ export default class GlobalHotkeysPlugin extends Plugin {
           const command = (this.app as any).commands.commands[command_id];
           if (!command) return;
           (this.app as any).setting.close(); // Ensure all modals are closed?
+          const anyFocusedBefore = (remote.BrowserWindow as any).getAllWindows().some((w: any) => w.isFocused());
           const win = remote.getCurrentWindow();
-          const wasHidden = !win.isFocused() || !win.isVisible();
 
           if (command.checkCallback)
             command.checkCallback(false);
           else if (command.callback)
             command.callback();
 
-          // only activate Obsidian if visibility hasn't changed
-          const isHidden = !win.isFocused() || !win.isVisible();
-          if (wasHidden && isHidden)
+          // only activate Obsidian if no window is currently focused.
+          // This prevents stealing focus from a newly created window.
+          const anyFocusedAfter = (remote.BrowserWindow as any).getAllWindows().some((w: any) => w.isFocused());
+          if (!anyFocusedBefore && !anyFocusedAfter)
             remote.getCurrentWindow().show(); // Activate obsidian
         });
       } catch (error) {
@@ -53,7 +54,7 @@ export default class GlobalHotkeysPlugin extends Plugin {
     }
   }
 
-  async unregisterGlobalShortcut(command_id:string) {
+  async unregisterGlobalShortcut(command_id: string) {
     const accelerator = this.currentlyMapped[command_id];
     if (accelerator) {
       globalShortcut.unregister(accelerator);
@@ -61,7 +62,7 @@ export default class GlobalHotkeysPlugin extends Plugin {
     }
   }
 
-  isRegistered(command_id:string) {
+  isRegistered(command_id: string) {
     return (command_id in this.currentlyMapped);
   }
 
@@ -143,14 +144,14 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
     });
   }
 
-  async removeSavedAccelerator(command_id:string) {
+  async removeSavedAccelerator(command_id: string) {
     this.plugin.unregisterGlobalShortcut(command_id);
     delete this.plugin.settings.accelerators[command_id];
     await this.plugin.saveSettings();
   }
 
   display(): void {
-    let {containerEl} = this;
+    let { containerEl } = this;
     this.settingElems = []
 
     containerEl.empty();
@@ -195,26 +196,26 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
       let setting = new Setting(containerEl)
         .setName(name)
         .addText(text => text
-                 .setPlaceholder('Hotkey')
-                 .setValue(accelerator)
-                 .onChange(async (value) => {
-                   const inputEl = (setting.components[0] as any).inputEl;
-                   if (value) {
-                     this.plugin.registerGlobalShortcut(cmd, value, async (success) => {
-                       if (success) {
-                         inputEl.classList.remove('invalid-accelerator');
-                         this.plugin.settings.accelerators[cmd] = value;
-                         await this.plugin.saveSettings();
-                       } else {
-                         this.removeSavedAccelerator(cmd);
-                         inputEl.classList.add('invalid-accelerator');
-                       }
-                     });
-                   } else {
-                     inputEl.classList.remove('invalid-accelerator');
-                     this.removeSavedAccelerator(cmd);
-                   }
-                 }));
+          .setPlaceholder('Hotkey')
+          .setValue(accelerator)
+          .onChange(async (value) => {
+            const inputEl = (setting.components[0] as any).inputEl;
+            if (value) {
+              this.plugin.registerGlobalShortcut(cmd, value, async (success) => {
+                if (success) {
+                  inputEl.classList.remove('invalid-accelerator');
+                  this.plugin.settings.accelerators[cmd] = value;
+                  await this.plugin.saveSettings();
+                } else {
+                  this.removeSavedAccelerator(cmd);
+                  inputEl.classList.add('invalid-accelerator');
+                }
+              });
+            } else {
+              inputEl.classList.remove('invalid-accelerator');
+              this.removeSavedAccelerator(cmd);
+            }
+          }));
       this.settingElems.push(setting);
     });
 

--- a/main.ts
+++ b/main.ts
@@ -23,9 +23,9 @@ export default class GlobalHotkeysPlugin extends Plugin {
     let success = (() => {
       try {
         return globalShortcut.register(accelerator, () => {
-          const command = app.commands.commands[command_id];
+          const command = (this.app as any).commands.commands[command_id];
           if (!command) return;
-          this.app.setting.close(); // Ensure all modals are closed?
+          (this.app as any).setting.close(); // Ensure all modals are closed?
           const win = remote.getCurrentWindow();
           const wasHidden = !win.isFocused() || !win.isVisible();
 
@@ -180,12 +180,12 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
       filterEl.setAttribute('placeholder', 'Filter...');
       filterEl.value = this.filterString;
       filterEl.addEventListener('input', e => {
-        this.filterString = e.target.value.toLowerCase();
+        this.filterString = (e.target as HTMLInputElement).value.toLowerCase();
         this.updateHotkeyVisibility();
       });
     });
 
-    let allCmds = this.app.commands.commands;
+    let allCmds = (this.app as any).commands.commands;
 
     const cmdKeys = Object.keys(allCmds);
     cmdKeys.sort((e1, e2) => (allCmds[e1].name < allCmds[e2].name) ? -1 : 1);
@@ -198,7 +198,7 @@ class GlobalShortcutSettingTab extends PluginSettingTab {
                  .setPlaceholder('Hotkey')
                  .setValue(accelerator)
                  .onChange(async (value) => {
-                   const inputEl = setting.components[0].inputEl;
+                   const inputEl = (setting.components[0] as any).inputEl;
                    if (value) {
                      this.plugin.registerGlobalShortcut(cmd, value, async (success) => {
                        if (success) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/node": "^14.14.37",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.11.0",
     "rollup": "^2.32.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"


### PR DESCRIPTION
I have updated the plugin to prevent Obsidian from stealing focus back to the main window when a global hotkey creates a new window in a different Space.

The plugin now only calls show() on the main window if Obsidian was completely unfocused before the command and remained unfocused after (indicating it was a background action that didn't create or focus a window).